### PR TITLE
 ServiceLevelIndicators.Asp set the activity status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ By default, an instrument named `LatencySLI` is added to the service metrics and
 * LocationId - The location id of where the service running. eg. Public cloud, West US 3 region.
 * Operation - The name of the operation. Defaults to `AttributeRouteInfo.Template` information like `GET Weatherforecast`.
 * activity.status_code - The activity status code tells if the operation succeeded or failed. [ActivityStatusCode](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activitystatuscode?view=net-7.0).
+    
+    If ServiceLevelIndicators.Asp is utilized, the activity status code will be designated as "Ok" when the http response status code is in the 2xx range,
+    "Error" when the http response status code is in the 5xx range,
+    and "Unset" for any other status code.
 * http.response.status_code - The http status code is added when ServiceLevelIndicators.Asp package is used. 
 * http.request.method - The http request method (GET, POST, etc) is added when ServiceLevelIndicators.Asp package is used. 
 * http.api.version - API Version is added when ServiceLevelIndicators.Asp.Versioning is used in conjuction with [API Versioning package](https://github.com/dotnet/aspnet-api-versioning).

--- a/ServiceLevelIndicators.Asp.ApiVersioning/tests/ServiceLevelIndicatorVersionedAspTests.cs
+++ b/ServiceLevelIndicators.Asp.ApiVersioning/tests/ServiceLevelIndicatorVersionedAspTests.cs
@@ -151,7 +151,7 @@ public class ServiceLevelIndicatorVersionedAspTests : IDisposable
                 new KeyValuePair<string, object?>("CustomerResourceId", "TestCustomerResourceId"),
                 new KeyValuePair<string, object?>("LocationId", "ms-loc://az/public/West US 3"),
                 new KeyValuePair<string, object?>("Operation", "GET "),
-                new KeyValuePair<string, object?>("activity.status_code", "Error"),
+                new KeyValuePair<string, object?>("activity.status_code", "Unset"),
                 new KeyValuePair<string, object?>("http.request.method", "GET"),
                 new KeyValuePair<string, object?>("http.response.status_code", 400),
         };

--- a/ServiceLevelIndicators.Asp/tests/ServiceLevelIndicatorAspTests.cs
+++ b/ServiceLevelIndicators.Asp/tests/ServiceLevelIndicatorAspTests.cs
@@ -108,7 +108,7 @@ public class ServiceLevelIndicatorAspTests : IDisposable
                 new KeyValuePair<string, object?>("CustomerResourceId", "TestCustomerResourceId"),
                 new KeyValuePair<string, object?>("LocationId", "ms-loc://az/public/West US 3"),
                 new KeyValuePair<string, object?>("Operation", "GET Test/bad_request"),
-                new KeyValuePair<string, object?>("activity.status_code", "Error"),
+                new KeyValuePair<string, object?>("activity.status_code", "Unset"),
                 new KeyValuePair<string, object?>("http.request.method", "GET"),
                 new KeyValuePair<string, object?>("http.response.status_code", 400),
             };

--- a/ServiceLevelIndicators/src/MeasuredOperationLatency.cs
+++ b/ServiceLevelIndicators/src/MeasuredOperationLatency.cs
@@ -31,7 +31,7 @@ public class MeasuredOperationLatency : IDisposable
     // OTEL Attributes to emit
     public List<KeyValuePair<string, object?>> Attributes { get; }
 
-    public void SetStatusCode(ActivityStatusCode activityStatusCode) => _activityStatusCode = activityStatusCode;
+    public void SetActivityStatusCode(ActivityStatusCode activityStatusCode) => _activityStatusCode = activityStatusCode;
 
     public void AddAttribute(string attribute, object? value) => Attributes.Add(new KeyValuePair<string, object?>(attribute, value));
 

--- a/ServiceLevelIndicators/tests/ServiceLevelIndicatorTests.cs
+++ b/ServiceLevelIndicators/tests/ServiceLevelIndicatorTests.cs
@@ -113,7 +113,7 @@ public class ServiceLevelIndicatorTests : IDisposable
         {
             using var measuredOperation = serviceLevelIndicator.StartLatencyMeasureOperation("SleepWorker");
             await Task.Delay(sleepTime);
-            measuredOperation.SetStatusCode(System.Diagnostics.ActivityStatusCode.Ok);
+            measuredOperation.SetActivityStatusCode(System.Diagnostics.ActivityStatusCode.Ok);
         }
     }
 

--- a/sample/WebApiVersioned/Controllers/2023-06-06/WeatherForecastController.cs
+++ b/sample/WebApiVersioned/Controllers/2023-06-06/WeatherForecastController.cs
@@ -94,7 +94,7 @@ public class WeatherForecastController : ControllerBase
         var attribute = new KeyValuePair<string, object?>("wait_seconds", seconds);
         using var measuredOperation = _serviceLevelIndicator.StartLatencyMeasureOperation("background_work", attribute);
         await Task.Delay(TimeSpan.FromSeconds(seconds));
-        measuredOperation.SetStatusCode(System.Diagnostics.ActivityStatusCode.Ok);
+        measuredOperation.SetActivityStatusCode(System.Diagnostics.ActivityStatusCode.Ok);
     }
 
     /// <summary>


### PR DESCRIPTION
If ServiceLevelIndicators.Asp is utilized, the activity status code will be designated as "Ok" when the http response status code is in the 2xx range,
"Error" when the http response status code is in the 5xx range,
and "Unset" for any other status code.