### PR TITLE
Add request.path if route description is missing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,7 @@ By default, an instrument named `LatencySLI` is added to the service metrics and
     ```
 
 4. Add the middleware to the pipeline.
-   If API versioning is used and want http.api.version as a SLI metric dimension, Use `app.UseServiceLevelIndicatorWithApiVersioning();`  
-   Otherwise, `app.UseServiceLevelIndicator();`
+   If API versioning is used and want http.api.version as a SLI metric dimension, Use `app.UseServiceLevelIndicatorWithApiVersioning();` else, `app.UseServiceLevelIndicator();`
 
 ### Customizations
 
@@ -157,13 +156,10 @@ eg GET WeatherForecast/Action1
 
     ``` csharp
         if (HttpContext.TryGetMeasuredOperationLatency(out var measuredOperationLatency))
-        {
             measuredOperationLatency.AddAttribute("CustomAttribute", value);
-            return Ok(true);
-        }
     ```
 
-- To prevent automatically emitting SLI information on all controllers, set the option.
+- To prevent automatically emitting SLI information on all controllers, set the option,
 
     ``` csharp
         ServiceLevelIndicatorOptions.AutomaticallyEmitted = false;
@@ -171,7 +167,7 @@ eg GET WeatherForecast/Action1
 
     In this case, add the attribute `[ServiceLevelIndicator]` on the controllers that should emit SLI.
 
-- To measure a process, run it withing a `StartLatencyMeasureOperation` using block.
+- To measure a process, run it within a `using StartLatencyMeasureOperation` block.
 
    Example.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ By default, an instrument named `LatencySLI` is added to the service metrics and
 
 ## Usage
 
-
 1. Create and register a metrics meter with the dependency injection.
 
    Example.
@@ -75,10 +74,11 @@ By default, an instrument named `LatencySLI` is added to the service metrics and
     }
     builder.Services.AddSingleton<SampleApiMeters>();
     ```
-    
+
 2. Add a class to configure SLI
 
     Example.
+
     ```csharp
     internal sealed class ConfigureServiceLevelIndicatorOptions : IConfigureOptions<ServiceLevelIndicatorOptions>
     {
@@ -107,12 +107,9 @@ By default, an instrument named `LatencySLI` is added to the service metrics and
     });
     ```
 
-4.  Add the middleware to the pipeline.
-        
-   If API versioning is used and want http.api.version as a SLI metric dimension, Use `app.UseServiceLevelIndicatorWithApiVersioning();`
-   
+4. Add the middleware to the pipeline.
+   If API versioning is used and want http.api.version as a SLI metric dimension, Use `app.UseServiceLevelIndicatorWithApiVersioning();`  
    Otherwise, `app.UseServiceLevelIndicator();`
-        
 
 ### Customizations
 
@@ -120,7 +117,7 @@ Once the Prerequisites are done, all controllers will emit SLI information.
 The default operation name is in the format &lt;HTTP Method&gt; &lt;Controller&gt;/&lt;Action&gt;. 
 eg GET WeatherForecast/Action1
 
-* To override the default operation name add the attribute `[ServiceLevelIndicator]` and specify the operation name.
+- To override the default operation name add the attribute `[ServiceLevelIndicator]` and specify the operation name.
 
    Example.
 
@@ -130,14 +127,15 @@ eg GET WeatherForecast/Action1
     public IEnumerable<WeatherForecast> GetOperation() => GetWeather();
     ```
 
-* To override the `CustomerResourceId` within an API method, mark the parameter with the attribute `[CustomerResourceId]`
+- To override the `CustomerResourceId` within an API method, mark the parameter with the attribute `[CustomerResourceId]`
+
     ```csharp
         [HttpGet("get-by-zip-code/{zipCode}")]
         public IEnumerable<WeatherForecast> GetByZipcode([CustomerResourceId] string zipCode) => GetWeather();
     ```
- 
+
     Or use `GetMeasuredOperationLatency` extension method.
-        
+
     ``` csharp
     [HttpGet("{customerResourceId}")]
     public IEnumerable<WeatherForecast> Get(string customerResourceId)
@@ -147,18 +145,33 @@ eg GET WeatherForecast/Action1
     }
     ```
 
-* To add custom Open Telemetry attributes.
-    ``` csharp 
+- To add custom Open Telemetry attributes.  
+
+    ``` csharp
         HttpContext.GetMeasuredOperationLatency().AddAttribute(attribute, value);
     ```
 
-* To prevent automatically emitting SLI information on all controllers, set the option.
-    ``` csharp 
+    GetMeasuredOperationLatency will **throw** if the route is not configured to emit SLI.
+
+    When used in a middleware or scenarios where a route may not be configured to emit SLI.
+
+    ``` csharp
+        if (HttpContext.TryGetMeasuredOperationLatency(out var measuredOperationLatency))
+        {
+            measuredOperationLatency.AddAttribute("CustomAttribute", value);
+            return Ok(true);
+        }
+    ```
+
+- To prevent automatically emitting SLI information on all controllers, set the option.
+
+    ``` csharp
         ServiceLevelIndicatorOptions.AutomaticallyEmitted = false;
     ```
+
     In this case, add the attribute `[ServiceLevelIndicator]` on the controllers that should emit SLI.
-    
-* To measure a process, run it withing a `StartLatencyMeasureOperation` using block.
+
+- To measure a process, run it withing a `StartLatencyMeasureOperation` using block.
 
    Example.
 

--- a/ServiceLevelIndicators.Asp.ApiVersioning/tests/ServiceLevelIndicatorVersionedAspTests.cs
+++ b/ServiceLevelIndicators.Asp.ApiVersioning/tests/ServiceLevelIndicatorVersionedAspTests.cs
@@ -140,9 +140,9 @@ public class ServiceLevelIndicatorVersionedAspTests : IDisposable
     }
 
     [Theory]
-    [InlineData("testSingle?api-version=invalid")]
-    [InlineData("testDouble?api-version=2023-08-29&api-version=2023-09-01")]
-    public async Task SLI_Metrics_is_emitted_when_invalid_api_version(string route)
+    [InlineData("testSingle", "api-version=invalid")]
+    [InlineData("testDouble", "api-version=2023-08-29&api-version=2023-09-01")]
+    public async Task SLI_Metrics_is_emitted_when_invalid_api_version(string route, string version)
     {
         // Arrange
         _expectedTags = new KeyValuePair<string, object?>[]
@@ -150,15 +150,16 @@ public class ServiceLevelIndicatorVersionedAspTests : IDisposable
                 new KeyValuePair<string, object?>("http.api.version", string.Empty),
                 new KeyValuePair<string, object?>("CustomerResourceId", "TestCustomerResourceId"),
                 new KeyValuePair<string, object?>("LocationId", "ms-loc://az/public/West US 3"),
-                new KeyValuePair<string, object?>("Operation", "GET "),
+                new KeyValuePair<string, object?>("Operation", "GET /" + route),
                 new KeyValuePair<string, object?>("activity.status_code", "Unset"),
                 new KeyValuePair<string, object?>("http.request.method", "GET"),
                 new KeyValuePair<string, object?>("http.response.status_code", 400),
         };
+        var routeWithVersion = route + "?" + version;
         using var host = await CreateHost();
 
         // Act
-        var response = await host.GetTestClient().GetAsync(route);
+        var response = await host.GetTestClient().GetAsync(routeWithVersion);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);

--- a/ServiceLevelIndicators.Asp/src/HttpContextExtensions.cs
+++ b/ServiceLevelIndicators.Asp/src/HttpContextExtensions.cs
@@ -5,11 +5,41 @@ using Microsoft.AspNetCore.Http.Features;
 
 public static class HttpContextExtensions
 {
+    /// <summary>
+    /// Gets the MeasuredOperationLatency from the IServiceLevelIndicatorFeature.
+    /// The method will throw an exception if the route is not configured to emit SLI metrics.
+    /// </summary>
+    /// <param name="context"></param>
+    /// <returns>MeasuredOperationLatency for the current API method.</returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="InvalidOperationException">If the route does not emit SLI information and therefore MeasuredOperationLatency does not exist.</exception>
     public static MeasuredOperationLatency GetMeasuredOperationLatency(this HttpContext context)
     {
         if (context == null)
             throw new ArgumentNullException(nameof(context));
 
         return context.Features.GetRequiredFeature<IServiceLevelIndicatorFeature>().MeasuredOperationLatency;
+    }
+
+    /// <summary>
+    /// Gets the MeasuredOperationLatency from the IServiceLevelIndicatorFeature.
+    /// </summary>
+    /// <param name="context"></param>
+    /// <param name="measuredOperationLatency"></param>
+    /// <returns>true if MeasuredOperationLatency exists.</returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static bool TryGetMeasuredOperationLatency(this HttpContext context, out MeasuredOperationLatency measuredOperationLatency)
+    {
+        if (context == null)
+            throw new ArgumentNullException(nameof(context));
+
+        if (context.Features.Get<IServiceLevelIndicatorFeature>() is IServiceLevelIndicatorFeature feature)
+        {
+            measuredOperationLatency = feature.MeasuredOperationLatency;
+            return true;
+        }
+
+        measuredOperationLatency = null!;
+        return false;
     }
 }

--- a/ServiceLevelIndicators.Asp/src/HttpContextExtensions.cs
+++ b/ServiceLevelIndicators.Asp/src/HttpContextExtensions.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceLevelIndicators;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 
@@ -28,7 +29,7 @@ public static class HttpContextExtensions
     /// <param name="measuredOperationLatency"></param>
     /// <returns>true if MeasuredOperationLatency exists.</returns>
     /// <exception cref="ArgumentNullException"></exception>
-    public static bool TryGetMeasuredOperationLatency(this HttpContext context, out MeasuredOperationLatency measuredOperationLatency)
+    public static bool TryGetMeasuredOperationLatency(this HttpContext context, [MaybeNullWhen(false)] out MeasuredOperationLatency measuredOperationLatency)
     {
         if (context == null)
             throw new ArgumentNullException(nameof(context));
@@ -39,7 +40,7 @@ public static class HttpContextExtensions
             return true;
         }
 
-        measuredOperationLatency = null!;
+        measuredOperationLatency = null;
         return false;
     }
 }

--- a/ServiceLevelIndicators.Asp/src/ServiceLevelIndicatorMiddleware.cs
+++ b/ServiceLevelIndicators.Asp/src/ServiceLevelIndicatorMiddleware.cs
@@ -71,7 +71,8 @@ internal sealed class ServiceLevelIndicatorMiddleWare
         if (attrib is null || string.IsNullOrEmpty(attrib.Operation))
         {
             var description = metadata.GetMetadata<ControllerActionDescriptor>();
-            return context.Request.Method + " " + description?.AttributeRouteInfo?.Template;
+            var path = description?.AttributeRouteInfo?.Template ?? context.Request.Path;
+            return context.Request.Method + " " + path;
         }
 
         return attrib.Operation;

--- a/ServiceLevelIndicators.Asp/tests/TestController.cs
+++ b/ServiceLevelIndicators.Asp/tests/TestController.cs
@@ -31,12 +31,12 @@ public class TestController : ControllerBase
     [HttpGet("try_get_measured_operation_latency/{value}")]
     public IActionResult TryGetMeasuredOperationLatency(string value)
     {
-        var result = HttpContext.TryGetMeasuredOperationLatency(out var measuredOperationLatency);
-        if (result)
+        if (HttpContext.TryGetMeasuredOperationLatency(out var measuredOperationLatency))
         {
             measuredOperationLatency.AddAttribute("CustomAttribute", value);
+            return Ok(true);
         }
-        return Ok(HttpContext.TryGetMeasuredOperationLatency(out _));
+        return Ok(false);
     }
 
     [HttpGet("send_sli")]

--- a/ServiceLevelIndicators.Asp/tests/TestController.cs
+++ b/ServiceLevelIndicators.Asp/tests/TestController.cs
@@ -28,6 +28,17 @@ public class TestController : ControllerBase
         return Ok(value);
     }
 
+    [HttpGet("try_get_measured_operation_latency/{value}")]
+    public IActionResult TryGetMeasuredOperationLatency(string value)
+    {
+        var result = HttpContext.TryGetMeasuredOperationLatency(out var measuredOperationLatency);
+        if (result)
+        {
+            measuredOperationLatency.AddAttribute("CustomAttribute", value);
+        }
+        return Ok(HttpContext.TryGetMeasuredOperationLatency(out _));
+    }
+
     [HttpGet("send_sli")]
     [ServiceLevelIndicator]
     public IActionResult SendSLI() => Ok("Hello");

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.1-alpha.{height}",
+  "version": "1.1",
   "nuGetPackageVersion": {
     "semVer": 2.0
   },


### PR DESCRIPTION
Add request.path if route description is missing.
Add TryGetMeasuredOperationLatency method.