### PR TITLE
ci: reuse Trellis Framework's CI/test infrastructure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,21 +9,31 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '8.0.x'
-            
-    - uses: actions/checkout@v6
+        dotnet-version: '10.0.x'
+
+    - name: Cache NuGet packages
+      uses: actions/cache@v5
       with:
-        fetch-depth: 0 # depth is needed for nbgv
-    - uses: dotnet/nbgv@master
-      with:
-        setAllVars: true
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+
+    - name: Setup versioning
+      run: |
+        dotnet tool install --global nbgv
+        nbgv cloud
 
     - name: Restore dependencies
       run: dotnet restore
@@ -31,15 +41,38 @@ jobs:
     - name: Build
       run: dotnet build --no-restore -c Release
 
-    - name: Test
-      run: dotnet test --no-build  -l "console;verbosity=normal" -c Release
+    - name: Test with Coverage
+      # --coverage: Native MTP coverage (requires Microsoft.Testing.Extensions.CodeCoverage)
+      # --report-trx: Native MTP TRX generation (requires Microsoft.Testing.Extensions.TrxReport)
+      # --results-directory is a VSTest-only flag that forces the VSTest code path, breaking MTP flags.
+      # MTP writes TRX to TestResults/ relative to each test project directory; coverage path is set explicitly via --coverage-output.
+      run: |
+        dotnet test --no-build -c Release \
+          --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml \
+          --report-trx
+
+    - name: Publish Test Results
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      if: always()
+      with:
+        files: |
+          **/TestResults/**/*.trx
+
+    - name: Upload Coverage to Codecov
+      uses: codecov/codecov-action@v5
+      if: always()
+      with:
+        # MTP writes coverage relative to each test project; search recursively
+        files: ./**/*.cobertura.xml
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: false
 
     - name: Pack
       if: ${{ success() && !github.base_ref }}
-      run: |
-        dotnet pack --no-build --verbosity normal -c Release -o artifacts/
-        
-    - uses: actions/upload-artifact@v6
+      run: dotnet pack --no-build --verbosity normal -c Release -o artifacts/
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v6
       if: ${{ success() && !github.base_ref }}
       with:
         name: artifact

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,8 @@
     <PackageVersion Include="FluentAssertions" Version="7.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.0.6" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.9.1" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/build/test.props
+++ b/build/test.props
@@ -1,24 +1,22 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+
     <NoWarn>$(NoWarn);CA1707</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <Using Include="FluentAssertions" />
     <Using Include="Xunit" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.v3"/>
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="FluentAssertions" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
+  </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,9 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.201",
     "rollForward": "latestFeature"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }


### PR DESCRIPTION
## Summary

The `main` build is broken (run [24858691310](https://github.com/xavierjohn/ServiceLevelIndicators/actions/runs/24858691310/job/72778369269)) with:

```
##[error]Unable to process file command 'env' successfully.
##[error]Invalid format '+ccedc1dc58'
```

**Root cause**: `dotnet/nbgv@master` writes `NBGV_BuildMetadataFragment=+ccedc1dc58` to `$GITHUB_ENV` without escaping the leading `+`. The runner refuses to parse the line and the job dies.

Rather than patch around the broken action, this PR adopts the Trellis Framework's CI/test infrastructure verbatim, which has been green for many runs.

## Changes

- **`.github/workflows/build.yml`** — replaced wholesale:
  - `actions/setup-dotnet@v5` with `dotnet-version: 10.0.x`
  - NuGet package cache
  - Versioning via `dotnet tool install --global nbgv && nbgv cloud` (no buggy action)
  - MTP-native coverage (`--coverage --coverage-output-format cobertura`) and TRX (`--report-trx`)
  - `EnricoMi/publish-unit-test-result-action@v2` for test results
  - `codecov/codecov-action@v5` for coverage upload
  - Pack + upload-artifact gated on push (not PR)
- **`global.json`** — bumped SDK to `10.0.201` and added `test.runner: Microsoft.Testing.Platform` so `dotnet test` routes through MTP instead of legacy VSTest (required for `--coverage`/`--report-trx` flags).
- **`build/test.props`** — switched test projects to MTP runner: `OutputType=Exe`, `UseMicrosoftTestingPlatformRunner=true`; replaced coverlet + xunit.runner.visualstudio with `Microsoft.Testing.Extensions.{CodeCoverage,TrxReport}`.
- **`Directory.Packages.props`** — pinned the two MTP-extension package versions (`18.0.6` / `1.9.1`).

## Verification (local)

```
dotnet restore       ✓ all 10 projects
dotnet build -c Rel  ✓ 0 warnings, 0 errors
dotnet test ... --coverage --report-trx
                     ✓ 52/52 passed, cobertura + trx artifacts produced
dotnet pack          ✓ 3 nupkgs
```

## Why not just patch the old workflow?

We could pin nbgv tool version or work around the action's env-write bug, but the framework's pipeline already solved this and adds useful infra (caching, codecov, MTP) that we'd want anyway. Keeping the two repos' CI in sync reduces maintenance burden going forward.