### PR TITLE
ci: add Publish NuGet Package workflow (mirrors framework)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,122 @@
+name: Publish NuGet Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (do not publish)'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0 # depth is needed for nbgv
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '10.0.x'
+
+    - name: Cache NuGet packages
+      uses: actions/cache@v5
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+
+    - name: Setup versioning
+      run: |
+        dotnet tool install --global nbgv
+        nbgv cloud
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --no-restore --configuration Release
+
+    - name: Run tests
+      run: dotnet test --no-build --configuration Release
+
+    - name: Pack
+      run: dotnet pack --no-build --configuration Release --output nupkgs
+
+    - name: Install SBOM tool
+      run: dotnet tool install --global Microsoft.Sbom.DotNetTool --version 4.1.5
+
+    - name: Generate SBOM
+      shell: pwsh
+      run: |
+        $packagesDirectory = Join-Path $PWD 'nupkgs'
+        $sbomDirectory = Join-Path $PWD 'sbom'
+        $dropDirectory = Join-Path $sbomDirectory 'drop'
+
+        New-Item -ItemType Directory -Force -Path $sbomDirectory | Out-Null
+        New-Item -ItemType Directory -Force -Path $dropDirectory | Out-Null
+
+        $packageFiles = Get-ChildItem -Path $packagesDirectory -Filter *.nupkg
+
+        if ($packageFiles.Count -eq 0) {
+          throw 'No NuGet packages were produced for SBOM generation.'
+        }
+
+        foreach ($packageFile in $packageFiles) {
+          Copy-Item -Path $packageFile.FullName -Destination $dropDirectory -Force
+        }
+
+        $packageVersion = (dotnet msbuild ./Trellis.ServiceLevelIndicators/src/Trellis.ServiceLevelIndicators.csproj --getProperty:PackageVersion).Trim()
+
+        sbom-tool generate `
+          -b $dropDirectory `
+          -bc $PWD `
+          -pn 'Trellis.ServiceLevelIndicators' `
+          -pv $packageVersion `
+          -ps 'Xavier John' `
+          -nsb 'https://github.com/xavierjohn/ServiceLevelIndicators/sbom' `
+          -m $sbomDirectory `
+          -mi SPDX:3.0 `
+          -D true `
+          -V Information
+
+        Write-Host 'Generated SBOM manifests:'
+        Get-ChildItem -Path $sbomDirectory -Recurse -Filter *.spdx.json |
+          Select-Object FullName, Length |
+          Format-Table -AutoSize
+
+    - name: List packages
+      run: |
+        echo "Packages to be published:"
+        ls -lh nupkgs/*.nupkg
+
+    - name: Upload SBOMs
+      uses: actions/upload-artifact@v6
+      with:
+        name: sbom-spdx
+        path: sbom/_manifest/**
+
+    - name: Publish to NuGet
+      if: ${{ inputs.dry_run == 'false' }}
+      run: |
+        dotnet nuget push nupkgs/*.nupkg \
+          --api-key ${{ secrets.NUGET_API_KEY }} \
+          --source https://api.nuget.org/v3/index.json \
+          --skip-duplicate
+
+    - name: Dry run summary
+      if: ${{ inputs.dry_run == 'true' }}
+      run: |
+        echo "DRY RUN - Packages NOT published:"
+        ls -lh nupkgs/*.nupkg
+        echo ""
+        echo "To publish for real, re-run with dry_run = false"


### PR DESCRIPTION
## Summary

Adds a `Publish NuGet Package` workflow that mirrors the Trellis Framework's
publish pipeline so SLI nupkgs can be pushed to nuget.org with a single click.

## Workflow

- **Trigger**: `workflow_dispatch` only (manual). Optional `dry_run` input
  (default `false`); when `true`, the workflow builds, packs, generates the
  SBOM, and lists the artifacts but skips the `nuget push`.
- **Steps**: checkout (full depth for nbgv) → setup .NET 10 → cache NuGet →
  `nbgv cloud` for versioning → restore → build → test → pack to `nupkgs/` →
  generate SPDX 3.0 SBOM via `Microsoft.Sbom.DotNetTool` → upload SBOM
  artifact → `dotnet nuget push --skip-duplicate` to `api.nuget.org`.

## What gets published

All three packable libraries (versions stamped by nbgv from `version.json`):

- `Trellis.ServiceLevelIndicators`
- `Trellis.ServiceLevelIndicators.Asp`
- `Trellis.ServiceLevelIndicators.Asp.ApiVersioning`

## Required setup before first real run

Add the repository secret **`NUGET_API_KEY`** with a nuget.org API key scoped
to push these three package IDs. Recommended first invocation: run with
`dry_run = true` to verify the pack/SBOM steps end-to-end before publishing.

## Differences from TrellisFramework's publish.yml

- Drops `--filter-not-trait "Category=Integration"` (SLI tests don't use that
  trait).
- SBOM version probe and package metadata point at SLI's csproj/repo URL.