### PR TITLE
Fix: restore ProblemDetails errors-dict fix on main (was lost in branch ordering)

### DIFF
--- a/Trellis.ServiceLevelIndicators.Asp/src/ServiceLevelIndicatorServiceCollectionExtensions.cs
+++ b/Trellis.ServiceLevelIndicators.Asp/src/ServiceLevelIndicatorServiceCollectionExtensions.cs
@@ -11,7 +11,7 @@ public static class ServiceLevelIndicatorServiceCollectionExtensions
     public static IServiceLevelIndicatorBuilder AddMvc(this IServiceLevelIndicatorBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        builder.Services.AddMvcCore(static options => options.Conventions.Add(new ServiceLevelIndicatorConvention()));
+        builder.Services.Configure<Microsoft.AspNetCore.Mvc.MvcOptions>(static options => options.Conventions.Add(new ServiceLevelIndicatorConvention()));
         return builder;
     }
 

--- a/Trellis.ServiceLevelIndicators.Asp/src/ServiceLevelIndicatorServiceCollectionExtensions.cs
+++ b/Trellis.ServiceLevelIndicators.Asp/src/ServiceLevelIndicatorServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿namespace Trellis.ServiceLevelIndicators;
 
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -11,7 +12,7 @@ public static class ServiceLevelIndicatorServiceCollectionExtensions
     public static IServiceLevelIndicatorBuilder AddMvc(this IServiceLevelIndicatorBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        builder.Services.Configure<Microsoft.AspNetCore.Mvc.MvcOptions>(static options => options.Conventions.Add(new ServiceLevelIndicatorConvention()));
+        builder.Services.Configure<MvcOptions>(static options => options.Conventions.Add(new ServiceLevelIndicatorConvention()));
         return builder;
     }
 

--- a/Trellis.ServiceLevelIndicators.Asp/tests/ProblemDetailsInteropTests.cs
+++ b/Trellis.ServiceLevelIndicators.Asp/tests/ProblemDetailsInteropTests.cs
@@ -2,12 +2,14 @@ namespace Trellis.ServiceLevelIndicators.Asp.Tests;
 
 using System.Diagnostics.Metrics;
 using System.Net;
+using System.Reflection;
 using System.Text.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -42,19 +44,25 @@ public class ProblemDetailsInteropTests
             .ToHashSet();
 
         // Subject: a service collection with ONLY AddServiceLevelIndicator().AddMvc().
+        using var meter = new Meter(nameof(ProblemDetailsInteropTests));
         var services = new ServiceCollection();
         services.AddOptions();
         services.AddServiceLevelIndicator(options =>
         {
-            options.Meter = new Meter(nameof(ProblemDetailsInteropTests));
+            options.Meter = meter;
             options.CustomerResourceId = "TestCustomerResourceId";
             options.LocationId = ServiceLevelIndicator.CreateLocationId("public", "West US 3");
         }).AddMvc();
 
-        // The convention must be registered (functional check).
+        // The convention must be registered (functional check). MvcOptions.Conventions is
+        // IList<IApplicationModelConvention>; ASP.NET wraps an IParameterModelConvention in an
+        // internal adapter when added, so we can't pattern-match the stored instance directly.
+        // Instead, inspect each convention's fields for a wrapped ServiceLevelIndicatorConvention.
         using var provider = services.BuildServiceProvider();
         var mvcOptions = provider.GetRequiredService<IOptions<MvcOptions>>().Value;
-        mvcOptions.Conventions.Should().NotBeEmpty("AddMvc() must register a model convention.");
+        mvcOptions.Conventions.Should().Contain(
+            convention => WrapsServiceLevelIndicatorConvention(convention),
+            "AddMvc() must register the ServiceLevelIndicatorConvention.");
 
         // AddMvc() must NOT pull in the rest of MvcCore's service registrations. If any MvcCore-only
         // service types appear in our subject collection, AddMvc() is calling AddMvcCore() under the
@@ -120,6 +128,19 @@ public class ProblemDetailsInteropTests
                     .UseServiceLevelIndicator()
                     .UseEndpoints(endpoints => endpoints.MapControllers())))
             .StartAsync();
+
+    private static bool WrapsServiceLevelIndicatorConvention(IApplicationModelConvention convention)
+    {
+        if ((object)convention is ServiceLevelIndicatorConvention)
+            return true;
+
+        // ASP.NET wraps non-IApplicationModelConvention conventions (e.g. IParameterModelConvention)
+        // in an internal adapter that holds the inner convention in a private field.
+        const BindingFlags bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+        return convention.GetType()
+            .GetFields(bindingFlags)
+            .Any(f => f.GetValue(convention) is ServiceLevelIndicatorConvention);
+    }
 }
 
 [ApiController]

--- a/Trellis.ServiceLevelIndicators.Asp/tests/ProblemDetailsInteropTests.cs
+++ b/Trellis.ServiceLevelIndicators.Asp/tests/ProblemDetailsInteropTests.cs
@@ -81,6 +81,13 @@ public class ProblemDetailsInteropTests
             "AddMvc() must register only the convention, not invoke AddMvcCore(). " +
             "Re-invoking the MVC services pipeline interferes with IProblemDetailsService " +
             "polymorphic serialization of HttpValidationProblemDetails.");
+
+        // Targeted regression check: AddMvcCore() registers MVC's IProblemDetailsWriter
+        // (Microsoft.AspNetCore.Http namespace, so missed by the prefix filter above). That writer
+        // is the exact service whose stale registration caused the original 'errors'-stripping bug.
+        services.Should().NotContain(
+            d => d.ServiceType.FullName == "Microsoft.AspNetCore.Http.IProblemDetailsWriter",
+            "AddMvc() must not introduce IProblemDetailsWriter — that's what caused the 422 'errors' dict to be dropped.");
     }
 
     [Fact]

--- a/Trellis.ServiceLevelIndicators.Asp/tests/ProblemDetailsInteropTests.cs
+++ b/Trellis.ServiceLevelIndicators.Asp/tests/ProblemDetailsInteropTests.cs
@@ -1,0 +1,141 @@
+namespace Trellis.ServiceLevelIndicators.Asp.Tests;
+
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.Metrics;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Regression tests covering interop between <see cref="ServiceLevelIndicatorServiceCollectionExtensions.AddMvc"/>
+/// and the ASP.NET Core <c>IProblemDetailsService</c> pipeline registered via <c>AddProblemDetails()</c>.
+///
+/// Historical bug: <c>AddMvc()</c> previously called <c>services.AddMvcCore(...)</c> just to register a single
+/// MVC convention. Re-invoking the MVC services pipeline after the host had already called
+/// <c>AddControllers()</c> + <c>AddProblemDetails()</c> + <c>AddApiVersioning()...AddOpenApi()</c>
+/// caused the <c>IProblemDetailsService</c> writer to drop the runtime-typed <c>Errors</c> dictionary
+/// from <see cref="HttpValidationProblemDetails"/> responses (the writer fell back to the static base
+/// <see cref="ProblemDetails"/> type for serialization). Extensions on the base type (<c>traceId</c>, custom
+/// keys) survived; the validation <c>errors</c> dictionary did not.
+///
+/// The fix replaces <c>AddMvcCore(...)</c> with <c>Configure&lt;MvcOptions&gt;(...)</c>, which registers the
+/// convention without re-invoking the MVC services pipeline.
+/// </summary>
+public class ProblemDetailsInteropTests
+{
+    [Fact]
+    public void AddMvc_registers_ServiceLevelIndicatorConvention_without_calling_AddMvcCore()
+    {
+        // Baseline: capture the set of services AddMvcCore would have introduced.
+        var withMvcCore = new ServiceCollection();
+        withMvcCore.AddMvcCore();
+        var mvcCoreOnlyTypes = withMvcCore
+            .Select(d => d.ServiceType.FullName)
+            .Where(name => name is not null)
+            .ToHashSet();
+
+        // Subject: a service collection with ONLY AddServiceLevelIndicator().AddMvc().
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.AddServiceLevelIndicator(options =>
+        {
+            options.Meter = new Meter(nameof(ProblemDetailsInteropTests));
+            options.CustomerResourceId = "TestCustomerResourceId";
+            options.LocationId = ServiceLevelIndicator.CreateLocationId("public", "West US 3");
+        }).AddMvc();
+
+        // The convention must be registered (functional check).
+        using var provider = services.BuildServiceProvider();
+        var mvcOptions = provider.GetRequiredService<IOptions<MvcOptions>>().Value;
+        mvcOptions.Conventions.Should().NotBeEmpty("AddMvc() must register a model convention.");
+
+        // AddMvc() must NOT pull in the rest of MvcCore's service registrations. If any MvcCore-only
+        // service types appear in our subject collection, AddMvc() is calling AddMvcCore() under the
+        // hood and will interfere with the host's already-configured MVC + ProblemDetails pipeline.
+        var subjectTypes = services
+            .Select(d => d.ServiceType.FullName)
+            .Where(name => name is not null)
+            .ToHashSet();
+
+        var leakedMvcCoreServices = subjectTypes
+            .Intersect(mvcCoreOnlyTypes)
+            .Where(t => t!.StartsWith("Microsoft.AspNetCore.Mvc", StringComparison.Ordinal))
+            .ToList();
+
+        leakedMvcCoreServices.Should().BeEmpty(
+            "AddMvc() must register only the convention, not invoke AddMvcCore(). " +
+            "Re-invoking the MVC services pipeline interferes with IProblemDetailsService " +
+            "polymorphic serialization of HttpValidationProblemDetails.");
+    }
+
+    [Fact]
+    public async Task AddMvc_validation_problem_includes_errors_when_written_via_ProblemDetailsService()
+    {
+        using var meter = new Meter(nameof(ProblemDetailsInteropTests));
+        using var host = await CreateHost(meter);
+
+        var ct = TestContext.Current.CancellationToken;
+        var client = host.GetTestClient();
+        var response = await client.PostAsync("/problem/validate", content: null, ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        var body = await response.Content.ReadAsStringAsync(ct);
+
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+
+        root.TryGetProperty("status", out var status).Should().BeTrue();
+        status.GetInt32().Should().Be(StatusCodes.Status422UnprocessableEntity);
+
+        root.TryGetProperty("errors", out var errors).Should().BeTrue(
+            $"Validation 'errors' dictionary must round-trip through IProblemDetailsService. Body: {body}");
+        errors.ValueKind.Should().Be(JsonValueKind.Object);
+        errors.TryGetProperty("name", out _).Should().BeTrue($"Body: {body}");
+    }
+
+    private static async Task<IHost> CreateHost(Meter meter) =>
+        await new HostBuilder()
+            .ConfigureWebHost(webBuilder => webBuilder
+                .UseTestServer()
+                .ConfigureServices(services =>
+                {
+                    services.AddProblemDetails();
+                    services.AddControllers();
+                    services.AddServiceLevelIndicator(options =>
+                    {
+                        options.Meter = meter;
+                        options.CustomerResourceId = "TestCustomerResourceId";
+                        options.LocationId = ServiceLevelIndicator.CreateLocationId("public", "West US 3");
+                    }).AddMvc();
+                })
+                .Configure(app => app
+                    .UseRouting()
+                    .UseServiceLevelIndicator()
+                    .UseEndpoints(endpoints => endpoints.MapControllers())))
+            .StartAsync();
+}
+
+[ApiController]
+[Route("problem")]
+public sealed class ProblemDetailsTestController : ControllerBase
+{
+    // Mirrors what frameworks like Trellis.Asp's ResponseFailureWriter do: invoke
+    // Results.ValidationProblem(...).ExecuteAsync(httpContext), which writes via IProblemDetailsService.
+    [HttpPost("validate")]
+    public async Task Validate()
+    {
+        var errors = new Dictionary<string, string[]> { ["name"] = ["Name is required."] };
+        var result = Results.ValidationProblem(errors, statusCode: StatusCodes.Status422UnprocessableEntity);
+        await result.ExecuteAsync(HttpContext);
+    }
+}

--- a/Trellis.ServiceLevelIndicators.Asp/tests/ProblemDetailsInteropTests.cs
+++ b/Trellis.ServiceLevelIndicators.Asp/tests/ProblemDetailsInteropTests.cs
@@ -1,16 +1,13 @@
 namespace Trellis.ServiceLevelIndicators.Asp.Tests;
 
-using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.Metrics;
 using System.Net;
-using System.Net.Http.Json;
 using System.Text.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;


### PR DESCRIPTION
## Problem

PR #53 (the fix that stops AddMvc() from calling AddMvcCore() and silently dropping `HttpValidationProblemDetails.Errors`) was merged into the `dev/xavier/trellis-prefix` feature branch on 2026-04-23 at 21:00 UTC.

But PR #52 (which merged `dev/xavier/trellis-prefix` → `main`) was already merged ~20 hours earlier at 01:14 UTC. So the fix never reached `main`, and the `Trellis.ServiceLevelIndicators.Asp 10.0.0-preview.9` published from main lacks it. Consumers (e.g., the TodoSample template) still get 422 ProblemDetails responses with the `errors` dict stripped.

Verified by decompiling the published `Trellis.ServiceLevelIndicators.Asp.dll` from nuget.org — `AddMvc()` still calls `AddMvcCore(...)`, the exact code PR #53 fixed.

## Change

Cherry-picks the two PR #53 commits onto main:

* `ef89d5cd` — the actual fix (replace `AddMvcCore(...)` with `Configure<MvcOptions>(...)`) plus the `ProblemDetailsInteropTests` regression suite.
* `ba541697` — review feedback (drop unused usings).

The two CI commits from PR #53 (`edbdc3ae` + `02ed7052`) are intentionally **not** cherry-picked because the equivalent improvements already shipped via PR #54.

## Verification

* `dotnet build -c Release` — 0 warnings, 0 errors.
* `dotnet test -c Release` — 54/54 pass (includes new `ProblemDetailsInteropTests`).

## Follow-up

After merge: run the `Publish NuGet Package` workflow to produce `10.0.0-preview.10` so the template can pick up the fix.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>