### PR TITLE
Harden SLI production readiness

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,10 +14,10 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.3" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
-    <PackageVersion Include="OpenTelemetry" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.14.3" />
     <PackageVersion Include="Scalar.AspNetCore.Microsoft" Version="2.14.3" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,27 +5,28 @@
     <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.0" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
     <PackageVersion Include="Asp.Versioning.OpenApi" Version="10.0.0-rc.1" />
-    <PackageVersion Include="Azure.Core" Version="1.51.1" />
+    <PackageVersion Include="Azure.Core" Version="1.54.0" />
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="2.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.14.3" />
-    <PackageVersion Include="Scalar.AspNetCore.Microsoft" Version="2.14.3" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.14.4" />
+    <PackageVersion Include="Scalar.AspNetCore.Microsoft" Version="2.14.4" />
   </ItemGroup>
   <!-- Test -->
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />
     <PackageVersion Include="FluentAssertions" Version="7.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
+    <!-- Keep MTP extensions aligned with xunit.v3's Microsoft.Testing.Platform.MSBuild 1.9.x dependency. -->
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.0.6" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.9.1" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,7 +26,6 @@
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />
     <PackageVersion Include="FluentAssertions" Version="7.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.0.6" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.9.1" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ dotnet add package Trellis.ServiceLevelIndicators.Asp.ApiVersioning
     });
     ```
 
-2. Add ServiceLevelIndicator into the dependency injection. `AddMvc()` is required for overrides present in SLI attributes to take effect.
+2. Add ServiceLevelIndicator into the dependency injection. `AddMvc()` is required for overrides present in MVC SLI attributes to take effect.
 
    Example:
 
@@ -164,7 +164,7 @@ dotnet add package Trellis.ServiceLevelIndicators.Asp.ApiVersioning
         });
     ```
 
-2. Add ServiceLevelIndicator into the dependency injection.
+2. Add ServiceLevelIndicator into the dependency injection. By default, SLI is emitted for every routed endpoint when the middleware is present. Set `AutomaticallyEmitted = false` if you want Minimal APIs to opt in endpoint-by-endpoint with `.AddServiceLevelIndicator()`.
 
    Example:
 
@@ -183,7 +183,7 @@ dotnet add package Trellis.ServiceLevelIndicators.Asp.ApiVersioning
     app.UseServiceLevelIndicator();
     ```
 
-4. To each API route mapping, add `AddServiceLevelIndicator()`.
+4. Optional: when `AutomaticallyEmitted = false`, add `AddServiceLevelIndicator()` to each route mapping that should emit SLI metrics.
 
    Example:
 
@@ -288,8 +288,8 @@ The default operation name is the HTTP method plus the route template (placehold
 - To set the `CustomerResourceId` within an API method, mark the parameter with the attribute `[CustomerResourceId]`
 
     ```csharp
-    [HttpGet("get-by-zip-code/{zipCode}")]
-    public IEnumerable<WeatherForecast> GetByZipcode([CustomerResourceId] string zipCode)
+    [HttpGet("teams/{teamId}")]
+    public IEnumerable<WeatherForecast> GetByTeam([CustomerResourceId] string teamId)
        => GetWeather();
     ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Service level indicators (SLIs) are metrics used to track how a service is perfo
 **Trellis.ServiceLevelIndicators** emits operation latency metrics in milliseconds so service owners can monitor performance over time using dimensions that matter to their system.
 The metrics are emitted via the standard [.NET Meter Class](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.metrics.meter).
 
-By default, a meter named `ServiceLevelIndicator` with instrument name `operation.duration` is added to the service metrics. The metrics are emitted with the following [attributes](https://opentelemetry.io/docs/specs/otel/common/#attribute).
+By default, a meter named `Trellis.SLI` with instrument name `operation.duration` is added to the service metrics. The metrics are emitted with the following [attributes](https://opentelemetry.io/docs/specs/otel/common/#attribute).
 
 - CustomerResourceId - The **target resource** of the operation — the noun in the URL path being read or modified, normalized to a stable identifier (tenant, subscription, account, work item). **NOT** the caller, **NOT** a per-request GUID, **NOT** a user ID or email. Example: for `GET /teams/{teamId}` called by user `xa1` for team `team1`, the value is `"team1"`, not `"xa1"`. See the [ASP.NET Core package README](Trellis.ServiceLevelIndicators.Asp/src/README.md#what-customerresourceid-is--and-what-it-is-not) for the full mental model.
 - LocationId - The location where the service running. eg. Public cloud, West US 3 region. [Azure Core](https://learn.microsoft.com/en-us/dotnet/api/azure.core.azurelocation?view=azure-dotnet)

--- a/Trellis.ServiceLevelIndicators.Asp/src/README.md
+++ b/Trellis.ServiceLevelIndicators.Asp/src/README.md
@@ -50,7 +50,8 @@ builder.Services.AddServiceLevelIndicator(options =>
 
 app.UseServiceLevelIndicator();
 
-// Mark individual endpoints
+// Automatic emission is enabled by default. If you set
+// options.AutomaticallyEmitted = false, mark individual endpoints:
 app.MapGet("/hello", () => "Hello World!")
     .AddServiceLevelIndicator();
 ```
@@ -150,8 +151,8 @@ public IActionResult Get() => Ok();
 ### Set CustomerResourceId from a route parameter
 
 ```csharp
-[HttpGet("get-by-zip-code/{zipCode}")]
-public IActionResult GetByZipcode([CustomerResourceId] string zipCode) => Ok();
+[HttpGet("teams/{teamId}")]
+public IActionResult GetTeam([CustomerResourceId] string teamId) => Ok();
 ```
 
 Or imperatively:

--- a/Trellis.ServiceLevelIndicators.Asp/src/README.md
+++ b/Trellis.ServiceLevelIndicators.Asp/src/README.md
@@ -62,7 +62,7 @@ If you configure a custom `Meter` in `ServiceLevelIndicatorOptions`, register th
 
 ## Emitted Metrics
 
-A meter named `ServiceLevelIndicator` with instrument `operation.duration` (milliseconds) is emitted with the following attributes:
+A meter named `Trellis.SLI` with instrument `operation.duration` (milliseconds) is emitted with the following attributes:
 
 | Attribute | Description |
 |-----------|-------------|

--- a/Trellis.ServiceLevelIndicators.Asp/src/ServiceLevelIndicatorServiceCollectionExtensions.cs
+++ b/Trellis.ServiceLevelIndicators.Asp/src/ServiceLevelIndicatorServiceCollectionExtensions.cs
@@ -39,8 +39,3 @@ public static class ServiceLevelIndicatorServiceCollectionExtensions
         return builder;
     }
 }
-
-internal sealed class ServiceLevelIndicatorBuilder(IServiceCollection services) : IServiceLevelIndicatorBuilder
-{
-    public IServiceCollection Services => services;
-}

--- a/Trellis.ServiceLevelIndicators.Asp/tests/ServiceLevelIndicatorMinimalApiTests.cs
+++ b/Trellis.ServiceLevelIndicators.Asp/tests/ServiceLevelIndicatorMinimalApiTests.cs
@@ -175,6 +175,30 @@ public class ServiceLevelIndicatorMinimalApiTests : IDisposable
     }
 
     [Fact]
+    public async Task SLI_Metrics_is_automatically_emitted_for_minimal_api_when_automatic_emission_is_enabled()
+    {
+        // Arrange
+        using var host = await CreateMinimalApiHostWithAutomaticEmission();
+
+        // Act
+        var response = await host.GetTestClient().GetAsync("auto-sli", TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var expectedTags = new KeyValuePair<string, object?>[]
+        {
+            new("CustomerResourceId", "TestCustomerResourceId"),
+            new("LocationId", "ms-loc://az/public/West US 3"),
+            new("Operation", "GET /auto-sli"),
+            new("activity.status.code", "Ok"),
+            new("http.response.status.code", 200),
+        };
+
+        ValidateMetrics(expectedTags);
+    }
+
+    [Fact]
     public async Task SLI_Metrics_is_emitted_with_enrichment_for_minimal_api()
     {
         // Arrange
@@ -270,6 +294,34 @@ public class ServiceLevelIndicatorMinimalApiTests : IDisposable
                     app.UseEndpoints(endpoints =>
                         endpoints.MapGet("/hello", () => "Hello World!")
                             .AddServiceLevelIndicator());
+                }))
+            .StartAsync();
+
+    private async Task<IHost> CreateMinimalApiHostWithAutomaticEmission() =>
+        await new HostBuilder()
+            .ConfigureWebHost(webBuilder => webBuilder
+                .UseTestServer()
+                .ConfigureServices(services =>
+                {
+                    services.AddRouting();
+                    services.AddServiceLevelIndicator(options =>
+                    {
+                        options.Meter = _meter;
+                        options.CustomerResourceId = "TestCustomerResourceId";
+                        options.LocationId = ServiceLevelIndicator.CreateLocationId("public", "West US 3");
+                    });
+                })
+                .Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseServiceLevelIndicator();
+                    app.Use(async (context, next) =>
+                    {
+                        await Task.Delay(MillisecondsDelay);
+                        await next(context);
+                    });
+                    app.UseEndpoints(endpoints =>
+                        endpoints.MapGet("/auto-sli", () => "Auto SLI"));
                 }))
             .StartAsync();
 

--- a/Trellis.ServiceLevelIndicators/src/IServiceLevelIndicatorBuilder.cs
+++ b/Trellis.ServiceLevelIndicators/src/IServiceLevelIndicatorBuilder.cs
@@ -1,4 +1,4 @@
-﻿namespace Trellis.ServiceLevelIndicators;
+namespace Trellis.ServiceLevelIndicators;
 
 using Microsoft.Extensions.DependencyInjection;
 
@@ -11,4 +11,9 @@ public interface IServiceLevelIndicatorBuilder
     /// Gets the <see cref="IServiceCollection"/> where SLI services are registered.
     /// </summary>
     IServiceCollection Services { get; }
+}
+
+internal sealed class ServiceLevelIndicatorBuilder(IServiceCollection services) : IServiceLevelIndicatorBuilder
+{
+    public IServiceCollection Services => services;
 }

--- a/Trellis.ServiceLevelIndicators/src/MeasuredOperation.cs
+++ b/Trellis.ServiceLevelIndicators/src/MeasuredOperation.cs
@@ -13,6 +13,7 @@ public class MeasuredOperation : IDisposable
     private bool _disposed;
     private readonly ServiceLevelIndicator _serviceLevelIndicator;
     private readonly Stopwatch _stopWatch;
+    private readonly HashSet<string> _attributeNames;
     private ActivityStatusCode _activityStatusCode = ActivityStatusCode.Unset;
     private readonly object _disposeLock = new();
 
@@ -25,7 +26,15 @@ public class MeasuredOperation : IDisposable
         _serviceLevelIndicator = serviceLevelIndicator;
         Operation = operation;
         CustomerResourceId = customerResourceId;
-        Attributes = [.. attributes];
+        Attributes = new List<KeyValuePair<string, object?>>(attributes.Length);
+        _attributeNames = new HashSet<string>(attributes.Length, StringComparer.Ordinal);
+        for (var i = 0; i < attributes.Length; i++)
+        {
+            _serviceLevelIndicator.ValidateAttributeName(attributes[i].Key);
+            ValidateUniqueAttributeName(attributes[i].Key);
+            Attributes.Add(attributes[i]);
+        }
+
         _stopWatch = Stopwatch.StartNew();
     }
 
@@ -55,7 +64,22 @@ public class MeasuredOperation : IDisposable
     /// </summary>
     /// <param name="attribute">The attribute name.</param>
     /// <param name="value">The attribute value.</param>
-    public void AddAttribute(string attribute, object? value) => Attributes.Add(new KeyValuePair<string, object?>(attribute, value));
+    public void AddAttribute(string attribute, object? value)
+    {
+        _serviceLevelIndicator.ValidateAttributeName(attribute);
+        ValidateUniqueAttributeName(attribute);
+        Attributes.Add(new KeyValuePair<string, object?>(attribute, value));
+    }
+
+    private void ValidateUniqueAttributeName(string attribute)
+    {
+        if (!_attributeNames.Add(attribute))
+        {
+            throw new ArgumentException(
+                $"Service Level Indicator attribute '{attribute}' was added more than once. Metric attribute names must be unique.",
+                nameof(attribute));
+        }
+    }
 
     protected virtual void Dispose(bool disposing)
     {
@@ -68,7 +92,7 @@ public class MeasuredOperation : IDisposable
                     _stopWatch.Stop();
                     var elapsedTime = _stopWatch.ElapsedMilliseconds;
                     Attributes.Add(new KeyValuePair<string, object?>(_serviceLevelIndicator.ServiceLevelIndicatorOptions.ActivityStatusCodeAttributeName, _activityStatusCode.ToString()));
-                    _serviceLevelIndicator.Record(Operation, CustomerResourceId, elapsedTime, Attributes.ToArray());
+                    _serviceLevelIndicator.RecordMeasurement(Operation, CustomerResourceId, elapsedTime, Attributes.ToArray());
                 }
 
                 _disposed = true;

--- a/Trellis.ServiceLevelIndicators/src/README.md
+++ b/Trellis.ServiceLevelIndicators/src/README.md
@@ -43,26 +43,22 @@ builder.Services.AddOpenTelemetry()
         metrics.AddOtlpExporter();
     });
 
-builder.Services.Configure<ServiceLevelIndicatorOptions>(options =>
+builder.Services.AddServiceLevelIndicator(options =>
 {
     options.Meter = sliMeter;
     options.LocationId = ServiceLevelIndicator.CreateLocationId("public", "westus3");
     options.CustomerResourceId = "my-customer";
 });
-
-builder.Services.AddSingleton<ServiceLevelIndicator>();
 ```
 
 ### 2. Configure options
 
 ```csharp
-builder.Services.Configure<ServiceLevelIndicatorOptions>(options =>
+builder.Services.AddServiceLevelIndicator(options =>
 {
     options.LocationId = ServiceLevelIndicator.CreateLocationId("public", "westus3");
     options.CustomerResourceId = "my-customer";
 });
-
-builder.Services.AddSingleton<ServiceLevelIndicator>();
 ```
 
 ### 3. Measure operations
@@ -84,6 +80,8 @@ You can also pass custom attributes:
 var attribute = new KeyValuePair<string, object?>("Event", "OrderCreated");
 using var op = sli.StartMeasuring("ProcessOrder", attribute);
 ```
+
+Custom attribute names must be unique and must not reuse SLI-reserved tags such as `CustomerResourceId`, `LocationId`, `Operation`, or `activity.status.code`.
 
 ## Emitted Metrics
 

--- a/Trellis.ServiceLevelIndicators/src/README.md
+++ b/Trellis.ServiceLevelIndicators/src/README.md
@@ -85,7 +85,7 @@ Custom attribute names must be unique and must not reuse SLI-reserved tags such 
 
 ## Emitted Metrics
 
-A meter named `ServiceLevelIndicator` with instrument `operation.duration` (milliseconds) is emitted with the following attributes:
+A meter named `Trellis.SLI` with instrument `operation.duration` (milliseconds) is emitted with the following attributes:
 
 | Attribute | Description |
 |-----------|-------------|

--- a/Trellis.ServiceLevelIndicators/src/ServiceLevelIndicator.cs
+++ b/Trellis.ServiceLevelIndicators/src/ServiceLevelIndicator.cs
@@ -39,6 +39,7 @@ public sealed class ServiceLevelIndicator : IDisposable
 
         ArgumentException.ThrowIfNullOrWhiteSpace(ServiceLevelIndicatorOptions.LocationId, nameof(ServiceLevelIndicatorOptions.LocationId));
         ArgumentException.ThrowIfNullOrWhiteSpace(ServiceLevelIndicatorOptions.DurationInstrumentName, nameof(ServiceLevelIndicatorOptions.DurationInstrumentName));
+        ValidateActivityStatusCodeAttributeName();
 
         if (ServiceLevelIndicatorOptions.Meter == null)
         {
@@ -87,6 +88,14 @@ public sealed class ServiceLevelIndicator : IDisposable
     /// <param name="attributes">Additional measurement attributes.</param>
     public void Record(string operation, string customerResourceId, long elapsedTime, params KeyValuePair<string, object?>[] attributes)
     {
+        ValidateAttributes(attributes);
+        RecordMeasurement(operation, customerResourceId, elapsedTime, attributes);
+    }
+
+    internal void RecordMeasurement(string operation, string customerResourceId, long elapsedTime, params KeyValuePair<string, object?>[] attributes)
+    {
+        ValidateNoDuplicateAttributeNames(attributes);
+
         var tagList = new TagList
         {
             { "CustomerResourceId", customerResourceId },
@@ -107,6 +116,59 @@ public sealed class ServiceLevelIndicator : IDisposable
     /// <param name="attributes">Additional measurement attributes.</param>
     /// <returns>A <see cref="MeasuredOperation"/> that records the metric on disposal.</returns>
     public MeasuredOperation StartMeasuring(string operation, params KeyValuePair<string, object?>[] attributes) => new(this, operation, attributes);
+
+    internal void ValidateAttributeName(string attribute)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(attribute);
+
+        if (attribute is "CustomerResourceId" or "LocationId" or "Operation" ||
+            attribute == ServiceLevelIndicatorOptions.ActivityStatusCodeAttributeName)
+        {
+            throw new ArgumentException(
+                $"'{attribute}' is a reserved Service Level Indicator attribute name and cannot be used as a custom metric attribute.",
+                nameof(attribute));
+        }
+    }
+
+    private void ValidateActivityStatusCodeAttributeName()
+    {
+        var attribute = ServiceLevelIndicatorOptions.ActivityStatusCodeAttributeName;
+        ArgumentException.ThrowIfNullOrWhiteSpace(attribute, nameof(ServiceLevelIndicatorOptions.ActivityStatusCodeAttributeName));
+
+        if (attribute is "CustomerResourceId" or "LocationId" or "Operation")
+        {
+            throw new ArgumentException(
+                $"'{attribute}' is a reserved Service Level Indicator attribute name and cannot be used as the activity status code attribute name.",
+                nameof(ServiceLevelIndicatorOptions.ActivityStatusCodeAttributeName));
+        }
+    }
+
+    private void ValidateAttributes(ReadOnlySpan<KeyValuePair<string, object?>> attributes)
+    {
+        for (var i = 0; i < attributes.Length; i++)
+            ValidateAttributeName(attributes[i].Key);
+    }
+
+    private static void ValidateNoDuplicateAttributeNames(ReadOnlySpan<KeyValuePair<string, object?>> attributes)
+    {
+        HashSet<string>? names = null;
+
+        for (var i = 0; i < attributes.Length; i++)
+        {
+            names ??= new HashSet<string>(attributes.Length + 3, StringComparer.Ordinal)
+            {
+                "CustomerResourceId",
+                "LocationId",
+                "Operation"
+            };
+
+            if (!names.Add(attributes[i].Key))
+            {
+                throw new InvalidOperationException(
+                    $"Service Level Indicator attribute '{attributes[i].Key}' was added more than once. Metric attribute names must be unique.");
+            }
+        }
+    }
 
     /// <summary>
     /// Creates a customer resource identifier from a Service Tree GUID.

--- a/Trellis.ServiceLevelIndicators/src/ServiceLevelIndicator.cs
+++ b/Trellis.ServiceLevelIndicators/src/ServiceLevelIndicator.cs
@@ -89,6 +89,7 @@ public sealed class ServiceLevelIndicator : IDisposable
     public void Record(string operation, string customerResourceId, long elapsedTime, params KeyValuePair<string, object?>[] attributes)
     {
         ValidateAttributes(attributes);
+        ValidateDuplicateArgumentAttributeNames(attributes);
         RecordMeasurement(operation, customerResourceId, elapsedTime, attributes);
     }
 
@@ -147,6 +148,23 @@ public sealed class ServiceLevelIndicator : IDisposable
     {
         for (var i = 0; i < attributes.Length; i++)
             ValidateAttributeName(attributes[i].Key);
+    }
+
+    private static void ValidateDuplicateArgumentAttributeNames(ReadOnlySpan<KeyValuePair<string, object?>> attributes)
+    {
+        HashSet<string>? names = null;
+
+        for (var i = 0; i < attributes.Length; i++)
+        {
+            names ??= new HashSet<string>(attributes.Length, StringComparer.Ordinal);
+
+            if (!names.Add(attributes[i].Key))
+            {
+                throw new ArgumentException(
+                    $"Service Level Indicator attribute '{attributes[i].Key}' was added more than once. Metric attribute names must be unique.",
+                    nameof(attributes));
+            }
+        }
     }
 
     private static void ValidateRecordAttributeNames(ReadOnlySpan<KeyValuePair<string, object?>> attributes)

--- a/Trellis.ServiceLevelIndicators/src/ServiceLevelIndicator.cs
+++ b/Trellis.ServiceLevelIndicators/src/ServiceLevelIndicator.cs
@@ -94,7 +94,7 @@ public sealed class ServiceLevelIndicator : IDisposable
 
     internal void RecordMeasurement(string operation, string customerResourceId, long elapsedTime, params KeyValuePair<string, object?>[] attributes)
     {
-        ValidateNoDuplicateAttributeNames(attributes);
+        ValidateRecordAttributeNames(attributes);
 
         var tagList = new TagList
         {
@@ -119,7 +119,7 @@ public sealed class ServiceLevelIndicator : IDisposable
 
     internal void ValidateAttributeName(string attribute)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(attribute);
+        ArgumentException.ThrowIfNullOrWhiteSpace(attribute, nameof(attribute));
 
         if (attribute is "CustomerResourceId" or "LocationId" or "Operation" ||
             attribute == ServiceLevelIndicatorOptions.ActivityStatusCodeAttributeName)
@@ -149,12 +149,19 @@ public sealed class ServiceLevelIndicator : IDisposable
             ValidateAttributeName(attributes[i].Key);
     }
 
-    private static void ValidateNoDuplicateAttributeNames(ReadOnlySpan<KeyValuePair<string, object?>> attributes)
+    private static void ValidateRecordAttributeNames(ReadOnlySpan<KeyValuePair<string, object?>> attributes)
     {
         HashSet<string>? names = null;
 
         for (var i = 0; i < attributes.Length; i++)
         {
+            if (string.IsNullOrWhiteSpace(attributes[i].Key))
+            {
+                throw new ArgumentException(
+                    "Service Level Indicator attribute names cannot be null, empty, or whitespace.",
+                    nameof(attributes));
+            }
+
             names ??= new HashSet<string>(attributes.Length + 3, StringComparer.Ordinal)
             {
                 "CustomerResourceId",

--- a/Trellis.ServiceLevelIndicators/src/ServiceLevelIndicator.cs
+++ b/Trellis.ServiceLevelIndicators/src/ServiceLevelIndicator.cs
@@ -21,7 +21,7 @@ public sealed class ServiceLevelIndicator : IDisposable
     /// <summary>
     /// Default meter name used when no <see cref="Meter"/> is provided in options.
     /// </summary>
-    public const string DefaultMeterName = nameof(ServiceLevelIndicator);
+    public const string DefaultMeterName = "Trellis.SLI";
 
     /// <summary>
     /// Gets the options used to configure this instance.

--- a/Trellis.ServiceLevelIndicators/src/ServiceLevelIndicatorServiceCollectionExtensions.cs
+++ b/Trellis.ServiceLevelIndicators/src/ServiceLevelIndicatorServiceCollectionExtensions.cs
@@ -1,15 +1,18 @@
-﻿namespace Trellis.ServiceLevelIndicators;
+namespace Trellis.ServiceLevelIndicators;
 
 using Microsoft.Extensions.DependencyInjection;
 
-public static class IServiceCollectionExtensions
+/// <summary>
+/// Extension methods for registering Service Level Indicator services.
+/// </summary>
+public static class ServiceLevelIndicatorCoreServiceCollectionExtensions
 {
     /// <summary>
-    /// Add service level indicator options.
+    /// Adds Service Level Indicator services and options.
     /// </summary>
-    /// <param name="services">The <see cref="IServiceCollection"/> for adding services.</param>
-    /// <param name="configureOptions">A delegate to configure the <see cref="ServiceLevelIndicatorOptions"/>.</param>
-    /// <returns></returns>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureOptions">A delegate to configure <see cref="ServiceLevelIndicatorOptions"/>.</param>
+    /// <returns>A builder for chaining host-specific SLI integrations.</returns>
     public static IServiceLevelIndicatorBuilder AddServiceLevelIndicator(this IServiceCollection services, Action<ServiceLevelIndicatorOptions> configureOptions)
     {
         ArgumentNullException.ThrowIfNull(services);

--- a/Trellis.ServiceLevelIndicators/tests/ServiceLevelIndicatorMeterProviderBuilderExtensionsTests.cs
+++ b/Trellis.ServiceLevelIndicators/tests/ServiceLevelIndicatorMeterProviderBuilderExtensionsTests.cs
@@ -15,6 +15,7 @@ public class ServiceLevelIndicatorMeterProviderBuilderExtensionsTests
         var actual = builder.AddServiceLevelIndicatorInstrumentation();
 
         actual.Should().BeSameAs(builder);
+        ServiceLevelIndicator.DefaultMeterName.Should().Be("Trellis.SLI");
     }
 
     [Fact]

--- a/Trellis.ServiceLevelIndicators/tests/ServiceLevelIndicatorTests.cs
+++ b/Trellis.ServiceLevelIndicators/tests/ServiceLevelIndicatorTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 public class ServiceLevelIndicatorTests : IDisposable
@@ -352,6 +353,169 @@ public class ServiceLevelIndicatorTests : IDisposable
         Action disposeTwice = () => { sli.Dispose(); sli.Dispose(); };
         disposeTwice.Should().NotThrow();
     }
+
+    [Fact]
+    public void AddServiceLevelIndicator_registers_core_services_without_asp_package()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        var builder = services.AddServiceLevelIndicator(options =>
+        {
+            options.LocationId = "TestLocationId";
+            options.CustomerResourceId = "TestResourceId";
+        });
+
+        // Assert
+        builder.Services.Should().BeSameAs(services);
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(ServiceLevelIndicator) &&
+            descriptor.Lifetime == ServiceLifetime.Singleton);
+        services.Should().Contain(descriptor =>
+            descriptor.ServiceType == typeof(IConfigureOptions<ServiceLevelIndicatorOptions>));
+    }
+
+    [Theory]
+    [InlineData("CustomerResourceId")]
+    [InlineData("LocationId")]
+    [InlineData("Operation")]
+    [InlineData("activity.status.code")]
+    public void Record_rejects_reserved_custom_attribute_names(string reservedName)
+    {
+        // Arrange
+        var serviceLevelIndicator = CreateServiceLevelIndicator();
+
+        // Act
+        Action act = () => serviceLevelIndicator.Record(
+            "TestOperation",
+            elapsedTime: 1,
+            new KeyValuePair<string, object?>(reservedName, "override"));
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*reserved Service Level Indicator attribute name*");
+    }
+
+    [Theory]
+    [InlineData("CustomerResourceId")]
+    [InlineData("LocationId")]
+    [InlineData("Operation")]
+    [InlineData("activity.status.code")]
+    public void StartMeasuring_rejects_reserved_initial_attribute_names(string reservedName)
+    {
+        // Arrange
+        var serviceLevelIndicator = CreateServiceLevelIndicator();
+
+        // Act
+        Action act = () => serviceLevelIndicator.StartMeasuring(
+            "TestOperation",
+            new KeyValuePair<string, object?>(reservedName, "override"));
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*reserved Service Level Indicator attribute name*");
+    }
+
+    [Theory]
+    [InlineData("CustomerResourceId")]
+    [InlineData("LocationId")]
+    [InlineData("Operation")]
+    [InlineData("activity.status.code")]
+    public void MeasuredOperation_AddAttribute_rejects_reserved_attribute_names(string reservedName)
+    {
+        // Arrange
+        var serviceLevelIndicator = CreateServiceLevelIndicator();
+        using var measuredOperation = serviceLevelIndicator.StartMeasuring("TestOperation");
+
+        // Act
+        Action act = () => measuredOperation.AddAttribute(reservedName, "override");
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*reserved Service Level Indicator attribute name*");
+    }
+
+    [Fact]
+    public void StartMeasuring_rejects_duplicate_initial_attribute_names()
+    {
+        // Arrange
+        var serviceLevelIndicator = CreateServiceLevelIndicator();
+
+        // Act
+        Action act = () => serviceLevelIndicator.StartMeasuring(
+            "TestOperation",
+            new KeyValuePair<string, object?>("CustomAttribute", "first"),
+            new KeyValuePair<string, object?>("CustomAttribute", "second"));
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*added more than once*");
+    }
+
+    [Fact]
+    public void MeasuredOperation_AddAttribute_rejects_duplicate_attribute_names()
+    {
+        // Arrange
+        var serviceLevelIndicator = CreateServiceLevelIndicator();
+        using var measuredOperation = serviceLevelIndicator.StartMeasuring("TestOperation");
+        measuredOperation.AddAttribute("CustomAttribute", "first");
+
+        // Act
+        Action act = () => measuredOperation.AddAttribute("CustomAttribute", "second");
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*added more than once*");
+    }
+
+    [Fact]
+    public void Constructor_rejects_activity_status_attribute_name_that_collides_with_core_tags()
+    {
+        // Arrange
+        var options = new ServiceLevelIndicatorOptions
+        {
+            CustomerResourceId = "TestResourceId",
+            LocationId = "TestLocationId",
+            Meter = _meter,
+            ActivityStatusCodeAttributeName = "Operation"
+        };
+
+        // Act
+        Action act = () =>
+        {
+            using var serviceLevelIndicator = new ServiceLevelIndicator(Options.Create(options));
+        };
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*reserved Service Level Indicator attribute name*");
+    }
+
+    [Fact]
+    public void MeasuredOperation_Dispose_rejects_duplicate_attribute_names_added_by_direct_list_mutation()
+    {
+        // Arrange
+        var serviceLevelIndicator = CreateServiceLevelIndicator();
+        var measuredOperation = serviceLevelIndicator.StartMeasuring("TestOperation");
+        measuredOperation.Attributes.Add(new KeyValuePair<string, object?>("CustomAttribute", "first"));
+        measuredOperation.Attributes.Add(new KeyValuePair<string, object?>("CustomAttribute", "second"));
+
+        // Act
+        Action act = measuredOperation.Dispose;
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*added more than once*");
+    }
+
+    private ServiceLevelIndicator CreateServiceLevelIndicator() =>
+        new(Options.Create(new ServiceLevelIndicatorOptions
+        {
+            CustomerResourceId = "TestResourceId",
+            LocationId = "TestLocationId",
+            Meter = _meter
+        }));
 
     private void ValidateMetrics(int elapsedTime, string instrumentName = "operation.duration", int? approx = null)
     {

--- a/Trellis.ServiceLevelIndicators/tests/ServiceLevelIndicatorTests.cs
+++ b/Trellis.ServiceLevelIndicators/tests/ServiceLevelIndicatorTests.cs
@@ -397,6 +397,24 @@ public class ServiceLevelIndicatorTests : IDisposable
             .WithMessage("*reserved Service Level Indicator attribute name*");
     }
 
+    [Fact]
+    public void Record_rejects_duplicate_custom_attribute_names_as_argument_error()
+    {
+        // Arrange
+        var serviceLevelIndicator = CreateServiceLevelIndicator();
+
+        // Act
+        Action act = () => serviceLevelIndicator.Record(
+            "TestOperation",
+            elapsedTime: 1,
+            new KeyValuePair<string, object?>("CustomAttribute", "first"),
+            new KeyValuePair<string, object?>("CustomAttribute", "second"));
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*added more than once*");
+    }
+
     [Theory]
     [InlineData("CustomerResourceId")]
     [InlineData("LocationId")]

--- a/Trellis.ServiceLevelIndicators/tests/ServiceLevelIndicatorTests.cs
+++ b/Trellis.ServiceLevelIndicators/tests/ServiceLevelIndicatorTests.cs
@@ -437,6 +437,21 @@ public class ServiceLevelIndicatorTests : IDisposable
     }
 
     [Fact]
+    public void MeasuredOperation_AddAttribute_rejects_blank_attribute_name_with_parameter_name()
+    {
+        // Arrange
+        var serviceLevelIndicator = CreateServiceLevelIndicator();
+        using var measuredOperation = serviceLevelIndicator.StartMeasuring("TestOperation");
+
+        // Act
+        Action act = () => measuredOperation.AddAttribute(" ", "override");
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .Where(ex => ex.ParamName == "attribute");
+    }
+
+    [Fact]
     public void StartMeasuring_rejects_duplicate_initial_attribute_names()
     {
         // Arrange
@@ -507,6 +522,22 @@ public class ServiceLevelIndicatorTests : IDisposable
         // Assert
         act.Should().Throw<InvalidOperationException>()
             .WithMessage("*added more than once*");
+    }
+
+    [Fact]
+    public void MeasuredOperation_Dispose_rejects_blank_attribute_names_added_by_direct_list_mutation()
+    {
+        // Arrange
+        var serviceLevelIndicator = CreateServiceLevelIndicator();
+        var measuredOperation = serviceLevelIndicator.StartMeasuring("TestOperation");
+        measuredOperation.Attributes.Add(new KeyValuePair<string, object?>(" ", "invalid"));
+
+        // Act
+        Action act = measuredOperation.Dispose;
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*attribute names cannot be null, empty, or whitespace*");
     }
 
     private ServiceLevelIndicator CreateServiceLevelIndicator() =>

--- a/Trellis.ServiceLevelIndicators/tests/ServiceLevelIndicatorTests.cs
+++ b/Trellis.ServiceLevelIndicators/tests/ServiceLevelIndicatorTests.cs
@@ -22,7 +22,7 @@ public class ServiceLevelIndicatorTests : IDisposable
     public ServiceLevelIndicatorTests(ITestOutputHelper output)
     {
         _output = output;
-        const string MeterName = "ServiceLevelIndicator";
+        const string MeterName = "Trellis.SLI";
         _meter = new(MeterName);
         _meterListener = new()
         {

--- a/build/test.props
+++ b/build/test.props
@@ -13,7 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />

--- a/docs/api_reference/trellis-api-sli-asp.md
+++ b/docs/api_reference/trellis-api-sli-asp.md
@@ -275,7 +275,7 @@ public static class HttpContextExtensions
 The `ServiceLevelIndicatorMiddleware` (registered by `UseServiceLevelIndicator()`):
 
 1. Reads the resolved endpoint metadata. Skips emission when neither `AutomaticallyEmitted == true` nor a `ServiceLevelIndicatorAttribute` is present.
-2. Resolves the operation name (custom override via attribute, else route template, else `"<METHOD> <path>"`).
+2. Resolves the operation name (custom override via attribute, else route template, else `"<METHOD> <unrouted>"`).
 3. Collects `MeasureMetadata` route values into measurement attributes.
 4. Starts a `MeasuredOperation` and attaches an `IServiceLevelIndicatorFeature` to `HttpContext.Features`.
 5. Optionally overrides the customer id from a `CustomerResourceIdMetadata`-tagged route value.
@@ -298,6 +298,8 @@ builder.Services.AddOpenTelemetry()
 builder.Services.AddServiceLevelIndicator(o =>
 {
     o.LocationId = ServiceLevelIndicator.CreateLocationId("public", "westus3");
+    // Automatic emission is enabled by default. Set AutomaticallyEmitted = false
+    // to opt in endpoint-by-endpoint with AddServiceLevelIndicator().
 })
 .AddMvc()
 .AddHttpMethod();
@@ -322,6 +324,7 @@ public class WidgetsController : ControllerBase
 ## Typical usage (Minimal API)
 
 ```csharp
+// Required only when AutomaticallyEmitted = false.
 app.MapGet("/subs/{subscriptionId}/widgets/{widgetId}",
     ([CustomerResourceId] Guid subscriptionId, [Measure("widget.id")] Guid widgetId) => Results.Ok())
    .AddServiceLevelIndicator();

--- a/docs/api_reference/trellis-api-sli.md
+++ b/docs/api_reference/trellis-api-sli.md
@@ -19,7 +19,7 @@ Every measurement emits the following tags on instrument `operation.duration` (m
 | `Operation` | Caller-supplied operation name |
 | `activity.status.code` | Set on `MeasuredOperation` (`Unset` / `Ok` / `Error`) |
 
-Additional attributes can be appended via `MeasuredOperation.AddAttribute(...)` or the `attributes` parameter of `Record`/`StartMeasuring`.
+Additional attributes can be appended via `MeasuredOperation.AddAttribute(...)` or the `attributes` parameter of `Record`/`StartMeasuring`. Custom attributes must not reuse `CustomerResourceId`, `LocationId`, `Operation`, the configured activity-status tag name, or any other attribute name already present on the measurement.
 
 ---
 
@@ -35,7 +35,7 @@ public sealed class ServiceLevelIndicator : IDisposable
 
 Singleton service that creates and records SLI metrics using an OpenTelemetry `Histogram<long>`. Resolved via DI from `IOptions<ServiceLevelIndicatorOptions>`.
 
-**Disposal and meter ownership.** `ServiceLevelIndicator` owns the `Meter` only when it created it (i.e. when no `Meter` was supplied in `ServiceLevelIndicatorOptions`). On `Dispose()`, an internally-created meter is disposed; a user-supplied meter is never disposed by this class. Because the type is registered as a singleton via `AddSingleton<ServiceLevelIndicator>()`, the DI container disposes it at host shutdown — applications do not need to call `Dispose()` manually. `Dispose()` is idempotent. After disposal, recording is a silent no-op per OpenTelemetry convention.
+**Disposal and meter ownership.** `ServiceLevelIndicator` owns the `Meter` only when it created it (i.e. when no `Meter` was supplied in `ServiceLevelIndicatorOptions`). On `Dispose()`, an internally-created meter is disposed; a user-supplied meter is never disposed by this class. Because `AddServiceLevelIndicator(...)` registers the type as a singleton, the DI container disposes it at host shutdown — applications do not need to call `Dispose()` manually. `Dispose()` is idempotent. After disposal, recording is a silent no-op per OpenTelemetry convention.
 
 **Constants**
 
@@ -86,8 +86,22 @@ Bound via `IOptions<ServiceLevelIndicatorOptions>`. `LocationId` and `DurationIn
 | `CustomerResourceId` | `string` | `"Unset"` | Default `CustomerResourceId` tag value (per-tenant / per-subscription identifier). Can be overridden on each call. |
 | `LocationId` | `string` | `""` | **Required.** Where the service is running (e.g. `ms-loc://az/public/westus3`). Must be non-empty. |
 | `DurationInstrumentName` | `string` | `"operation.duration"` | **Required.** Histogram instrument name. Must be non-empty. |
-| `ActivityStatusCodeAttributeName` | `string` | `"activity.status.code"` | Tag name used to emit the operation's `ActivityStatusCode`. |
+| `ActivityStatusCodeAttributeName` | `string` | `"activity.status.code"` | Tag name used to emit the operation's `ActivityStatusCode`. Must be non-empty and cannot be `CustomerResourceId`, `LocationId`, or `Operation`. |
 | `AutomaticallyEmitted` | `bool` | `true` | When `false`, only operations explicitly opted-in (e.g. via the `[ServiceLevelIndicator]` attribute in the ASP package) emit metrics. |
+
+---
+
+### DI registration
+
+**Declaration**
+
+```csharp
+public static IServiceLevelIndicatorBuilder AddServiceLevelIndicator(
+    this IServiceCollection services,
+    Action<ServiceLevelIndicatorOptions> configureOptions)
+```
+
+Registers `ServiceLevelIndicator` as a singleton and configures `ServiceLevelIndicatorOptions`. This lives in the core package, so console apps, workers, and shared libraries do not need to reference the ASP package just to use DI. The returned `IServiceLevelIndicatorBuilder` exposes `Services` and is the chaining point for host packages such as `.AddMvc()`, `.AddHttpMethod()`, and `.AddApiVersion()`.
 
 ---
 
@@ -121,7 +135,7 @@ Represents an in-flight measurement. The stopwatch starts in the constructor; di
 | Signature | Returns | Description |
 |---|---|---|
 | `public void SetActivityStatusCode(ActivityStatusCode code)` | `void` | Sets the `ActivityStatusCode` recorded with the measurement. Default is `Unset`. |
-| `public void AddAttribute(string attribute, object? value)` | `void` | Appends a custom attribute to be emitted with the measurement. |
+| `public void AddAttribute(string attribute, object? value)` | `void` | Appends a custom attribute to be emitted with the measurement. Throws if the name collides with a reserved SLI tag. |
 | `public void Dispose()` | `void` | Stops the stopwatch and records the metric. Idempotent. |
 | `protected virtual void Dispose(bool disposing)` | `void` | Standard dispose pattern hook. |
 
@@ -201,8 +215,7 @@ builder.Services.AddOpenTelemetry()
         .AddServiceLevelIndicatorInstrumentation()
         .AddOtlpExporter());
 
-builder.Services.AddSingleton<ServiceLevelIndicator>();
-builder.Services.Configure<ServiceLevelIndicatorOptions>(o =>
+builder.Services.AddServiceLevelIndicator(o =>
 {
     o.LocationId = ServiceLevelIndicator.CreateLocationId("public", "westus3");
 });

--- a/docs/api_reference/trellis-api-sli.md
+++ b/docs/api_reference/trellis-api-sli.md
@@ -41,7 +41,7 @@ Singleton service that creates and records SLI metrics using an OpenTelemetry `H
 
 | Name | Type | Value | Description |
 |---|---|---|---|
-| `DefaultMeterName` | `const string` | `"ServiceLevelIndicator"` | Default meter name used when no `Meter` is supplied in options. |
+| `DefaultMeterName` | `const string` | `"Trellis.SLI"` | Default meter name used when no `Meter` is supplied in options. |
 
 **Properties**
 
@@ -53,7 +53,7 @@ Singleton service that creates and records SLI metrics using an OpenTelemetry `H
 
 | Signature | Description |
 |---|---|
-| `public ServiceLevelIndicator(IOptions<ServiceLevelIndicatorOptions> options)` | Validates `LocationId` and `DurationInstrumentName`, creates the default meter (`"ServiceLevelIndicator"` + assembly version) when one isn't supplied, and creates the `operation.duration` histogram. |
+| `public ServiceLevelIndicator(IOptions<ServiceLevelIndicatorOptions> options)` | Validates `LocationId` and `DurationInstrumentName`, creates the default meter (`"Trellis.SLI"` + assembly version) when one isn't supplied, and creates the `operation.duration` histogram. |
 
 **Methods**
 
@@ -199,7 +199,7 @@ Helpers for wiring the SLI meter into an OpenTelemetry pipeline.
 
 | Signature | Returns | Description |
 |---|---|---|
-| `public static MeterProviderBuilder AddServiceLevelIndicatorInstrumentation(this MeterProviderBuilder builder)` | `MeterProviderBuilder` | Adds the default meter `"ServiceLevelIndicator"`. |
+| `public static MeterProviderBuilder AddServiceLevelIndicatorInstrumentation(this MeterProviderBuilder builder)` | `MeterProviderBuilder` | Adds the default meter `"Trellis.SLI"`. |
 | `public static MeterProviderBuilder AddServiceLevelIndicatorInstrumentation(this MeterProviderBuilder builder, string meterName)` | `MeterProviderBuilder` | Adds a specific meter by name. Used when the application configures `ServiceLevelIndicatorOptions.Meter` with a custom meter. |
 | `public static MeterProviderBuilder AddServiceLevelIndicatorInstrumentation(this MeterProviderBuilder builder, Meter meter)` | `MeterProviderBuilder` | Convenience overload that reads the meter's name. |
 

--- a/docs/usage-reference.md
+++ b/docs/usage-reference.md
@@ -48,13 +48,11 @@ builder.Services.AddOpenTelemetry()
 Register the service:
 
 ```csharp
-builder.Services.Configure<ServiceLevelIndicatorOptions>(options =>
+builder.Services.AddServiceLevelIndicator(options =>
 {
     options.LocationId = ServiceLevelIndicator.CreateLocationId("public", "westus3");
     options.CustomerResourceId = "tenant-a";
 });
-
-builder.Services.AddSingleton<ServiceLevelIndicator>();
 ```
 
 Measure work:
@@ -91,14 +89,12 @@ builder.Services.AddOpenTelemetry()
         metrics.AddOtlpExporter();
     });
 
-builder.Services.Configure<ServiceLevelIndicatorOptions>(options =>
+builder.Services.AddServiceLevelIndicator(options =>
 {
     options.Meter = sliMeter;
     options.LocationId = ServiceLevelIndicator.CreateLocationId("public", "westus3");
     options.CustomerResourceId = "tenant-a";
 });
-
-builder.Services.AddSingleton<ServiceLevelIndicator>();
 ```
 
 Available registration overloads:
@@ -280,6 +276,7 @@ Avoid values that can explode cardinality unless your backend is designed for th
 3. Forgetting `AddMvc()` when relying on MVC conventions and attribute-based overrides.
 4. Forgetting `.AddServiceLevelIndicator()` on Minimal API endpoints when `AutomaticallyEmitted` is `false`.
 5. Renaming `CustomerResourceId` or `LocationId` even though downstream systems depend on those exact names.
+6. Reusing reserved tag names such as `CustomerResourceId`, `LocationId`, `Operation`, or `activity.status.code` as custom attributes.
 
 ## Public API Cheat Sheet
 

--- a/docs/usage-reference.md
+++ b/docs/usage-reference.md
@@ -16,7 +16,7 @@ These values are part of the library contract and should be treated as stable un
 
 | Metric element | Value |
 |---|---|
-| Meter name | `ServiceLevelIndicator` by default |
+| Meter name | `Trellis.SLI` by default |
 | Instrument name | `operation.duration` |
 | Unit | milliseconds (`ms`) |
 | Required tag | `CustomerResourceId` |

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
-{
+﻿{
   "sdk": {
-    "version": "10.0.201",
+    "version": "10.0.203",
     "rollForward": "latestFeature"
   },
   "test": {

--- a/sample/ConsoleApp/Program.cs
+++ b/sample/ConsoleApp/Program.cs
@@ -21,9 +21,9 @@ ResourceBuilder resourceBuilder = ResourceBuilder
     .AddService(ProgramName, serviceVersion: version, serviceInstanceId: Environment.MachineName);
 
 ServiceCollection services = new();
-services.Configure<ServiceLevelIndicatorOptions>(r =>
+services.AddServiceLevelIndicator(r =>
 {
-    r.CustomerResourceId = ProgramName; // Customer ID if this work is done on behalf of a customer.
+    r.CustomerResourceId = ProgramName; // Stable resource this background workload is measuring.
     r.LocationId = ServiceLevelIndicator.CreateLocationId("public", AzureLocation.WestUS3.Name);
 });
 
@@ -32,8 +32,7 @@ services
         {
             options.SetResourceBuilder(resourceBuilder);
             options.AddConsoleExporter();
-        }))
-    .AddSingleton<ServiceLevelIndicator>();
+        }));
 
 var serviceProvider = services.BuildServiceProvider();
 

--- a/sample/MinApi/Program.cs
+++ b/sample/MinApi/Program.cs
@@ -54,8 +54,14 @@ app.MapGet(
    .AddServiceLevelIndicator();
 
 app.MapGet(
-        "/background/{wait_seconds}",
-        ([Measure] int wait_seconds) => Task.Delay(TimeSpan.FromSeconds(wait_seconds)))
+        "/background/{workType:regex(^(Quick|Standard|Slow)$)}",
+        ([Measure("WorkType")] string workType) => Task.Delay(workType switch
+        {
+            nameof(WorkType.Quick) => TimeSpan.FromMilliseconds(250),
+            nameof(WorkType.Standard) => TimeSpan.FromSeconds(1),
+            nameof(WorkType.Slow) => TimeSpan.FromSeconds(2),
+            _ => TimeSpan.FromSeconds(1)
+        }))
    .AddServiceLevelIndicator("background_work");
 
 app.UseUserRoute();
@@ -68,4 +74,11 @@ app.Run();
 internal record WeatherForecast(DateTime Date, int TemperatureC, string? Summary)
 {
     public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}
+
+internal enum WorkType
+{
+    Quick,
+    Standard,
+    Slow
 }

--- a/sample/WebApiVersioned/Program.cs
+++ b/sample/WebApiVersioned/Program.cs
@@ -27,7 +27,11 @@ builder.Services.AddOpenTelemetry()
         builder.AddOtlpExporter();
     });
 
-builder.Services.AddServiceLevelIndicator(options => options.LocationId = ServiceLevelIndicator.CreateLocationId("public", AzureLocation.WestUS3.Name))
+builder.Services.AddServiceLevelIndicator(options =>
+{
+    options.CustomerResourceId = "SampleVersionedApiResource";
+    options.LocationId = ServiceLevelIndicator.CreateLocationId("public", AzureLocation.WestUS3.Name);
+})
 .AddMvc()
 .AddApiVersion();
 


### PR DESCRIPTION

This PR hardens ServiceLevelIndicators for production use and aligns the public docs/samples with the intended SLI
telemetry contract.

Changes

 - Moved core DI registration into Trellis.ServiceLevelIndicators
  - AddServiceLevelIndicator(...) now works from the core package without requiring the ASP package.
  - IServiceLevelIndicatorBuilder now lives in the core package.
  - ASP/API-versioning packages continue to chain from the same builder with .AddMvc(), .AddHttpMethod(), 
.Enrich(...), and .AddApiVersion().
 - Renamed the default meter
  - Changed default meter name from ServiceLevelIndicator to Trellis.SLI.
  - Kept the instrument name operation.duration, unit ms, and existing tag names unchanged.
 - Hardened metric attribute handling
  - Rejects custom attributes that collide with reserved SLI tags:
   - CustomerResourceId
   - LocationId
   - Operation
   - configured activity-status tag name, default activity.status.code
  - Rejects duplicate metric attribute names to avoid ambiguous/lossy telemetry.
  - Detects duplicates eagerly in MeasuredOperation constructor / AddAttribute(...), with a final guard at record 
time for direct list mutation.
 - Clarified ASP.NET Core emission behavior
  - Documented that Minimal APIs are automatically emitted by default when middleware is present.
  - Clarified .AddServiceLevelIndicator() is only required for endpoint-by-endpoint opt-in when AutomaticallyEmitted
 = false.
  - Corrected unrouted fallback docs to "<METHOD> <unrouted>".
 - Reduced cardinality-risk examples
  - Replaced unsafe/free-form sample dimensions with bounded examples.
  - Updated docs to discourage request IDs, emails, timestamps, arbitrary user input, and unbounded route values as 
metric dimensions.
  - Added bounded Minimal API sample route for WorkType.