### PR TITLE
docs: add YAML front matter to the SLI API reference docs

### DIFF
--- a/docs/api_reference/trellis-api-sli-apiversioning.md
+++ b/docs/api_reference/trellis-api-sli-apiversioning.md
@@ -1,3 +1,12 @@
+---
+package: Trellis.ServiceLevelIndicators.Asp.ApiVersioning
+namespaces: [Trellis.ServiceLevelIndicators]
+types: [ServiceLevelIndicatorServiceCollectionExtensions, ApiVersionEnrichment, AddApiVersion]
+version: v10
+last_verified: 2026-06-18
+audience: [llm]
+---
+
 # Trellis.ServiceLevelIndicators.Asp.ApiVersioning — API Reference
 
 **Package:** `Trellis.ServiceLevelIndicators.Asp.ApiVersioning`  

--- a/docs/api_reference/trellis-api-sli-asp.md
+++ b/docs/api_reference/trellis-api-sli-asp.md
@@ -1,3 +1,12 @@
+---
+package: Trellis.ServiceLevelIndicators.Asp
+namespaces: [Trellis.ServiceLevelIndicators]
+types: [IServiceLevelIndicatorBuilder, ServiceLevelIndicatorCoreServiceCollectionExtensions, ServiceLevelIndicatorServiceCollectionExtensions, ServiceLevelIndicatorApplicationBuilderExtensions, EndpointBuilderExtensions, ServiceLevelIndicatorAttribute, CustomerResourceIdAttribute, MeasureAttribute, CustomerResourceIdMetadata, MeasureMetadata, WebEnrichmentContext, IServiceLevelIndicatorFeature, HttpContextExtensions]
+version: v10
+last_verified: 2026-06-18
+audience: [llm]
+---
+
 # Trellis.ServiceLevelIndicators.Asp — API Reference
 
 **Package:** `Trellis.ServiceLevelIndicators.Asp`  

--- a/docs/api_reference/trellis-api-sli.md
+++ b/docs/api_reference/trellis-api-sli.md
@@ -1,3 +1,12 @@
+---
+package: Trellis.ServiceLevelIndicators
+namespaces: [Trellis.ServiceLevelIndicators]
+types: [ServiceLevelIndicator, ServiceLevelIndicatorOptions, MeasuredOperation, SliOutcome, IEnrichmentContext, "IEnrichment<T>", IServiceLevelIndicatorBuilder, ServiceLevelIndicatorMeterProviderBuilderExtensions, AddServiceLevelIndicator, AddServiceLevelIndicatorInstrumentation]
+version: v10
+last_verified: 2026-06-18
+audience: [llm]
+---
+
 # Trellis.ServiceLevelIndicators — API Reference
 
 **Package:** `Trellis.ServiceLevelIndicators`  


### PR DESCRIPTION
## Summary

The three SLI API reference docs (`docs/api_reference/trellis-api-sli*.md`) used bold-markdown headers (`**Package:**`, `**Namespace:**`, `**Purpose:**`) instead of the **YAML front matter** that the Trellis framework reference docs use. Any tooling/LLM indexing that keys off `audience: [llm]` or the `types:` metadata would skip or misclassify these three docs relative to the rest of the Trellis reference set.

## Change

Prepend the standard front matter to all three docs — **additive only**, the human-readable `**Package**` / `**Namespace**` / `**Purpose**` lines stay:

```yaml
---
package: Trellis.ServiceLevelIndicators
namespaces: [Trellis.ServiceLevelIndicators]
types: [ServiceLevelIndicator, ServiceLevelIndicatorOptions, ...]
version: v10
last_verified: 2026-06-18
audience: [llm]
---
```

`types` lists are extracted from each doc's `### Type` sections. Repo convention preserved (UTF-8 no-BOM, CRLF).

## Why this is the right layer

`docs/api_reference/` is the single source — `Directory.Build.targets` auto-packs each `trellis-api-<TrellisApiRefName>.md` into the package's `trellis/` folder. So a republish flows the metadata to **every** downstream consumer (the framework, both `dotnet new` templates, and any future consumer) instead of being patched per-repo.

## Verification

Packed `Trellis.ServiceLevelIndicators` locally — the `trellis/trellis-api-sli.md` entry inside the `.nupkg` now begins with the front matter block. Docs-only change; no code or test impact.

> Note: `version: v10` mirrors the framework's `v3` (major-version line) for the SLI 10.x packages — change if a different convention is preferred.
