### PR TITLE
chore: pre-publish NuGet bumps + tighten API-ref types front matter

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,26 +5,26 @@
     <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.0" />
     <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
     <PackageVersion Include="Asp.Versioning.OpenApi" Version="10.0.0-rc.1" />
-    <PackageVersion Include="Azure.Core" Version="1.54.0" />
-    <PackageVersion Include="DotNet.ReproducibleBuilds" Version="2.0.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
+    <PackageVersion Include="Azure.Core" Version="1.59.0" />
+    <PackageVersion Include="DotNet.ReproducibleBuilds" Version="2.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
-    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.14.4" />
-    <PackageVersion Include="Scalar.AspNetCore.Microsoft" Version="2.14.4" />
+    <PackageVersion Include="OpenTelemetry" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.4" />
+    <PackageVersion Include="Scalar.AspNetCore.Microsoft" Version="2.16.4" />
   </ItemGroup>
   <!-- Test -->
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />
-    <PackageVersion Include="FluentAssertions" Version="7.2.0" />
+    <PackageVersion Include="FluentAssertions" Version="7.2.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
     <!-- Keep MTP extensions aligned with xunit.v3's Microsoft.Testing.Platform.MSBuild 1.9.x dependency. -->
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.0.6" />

--- a/docs/api_reference/trellis-api-sli-apiversioning.md
+++ b/docs/api_reference/trellis-api-sli-apiversioning.md
@@ -1,7 +1,7 @@
 ---
 package: Trellis.ServiceLevelIndicators.Asp.ApiVersioning
 namespaces: [Trellis.ServiceLevelIndicators]
-types: [ServiceLevelIndicatorServiceCollectionExtensions, ApiVersionEnrichment, AddApiVersion]
+types: [ServiceLevelIndicatorServiceCollectionExtensions, ApiVersionEnrichment]
 version: v10
 last_verified: 2026-06-18
 audience: [llm]

--- a/docs/api_reference/trellis-api-sli.md
+++ b/docs/api_reference/trellis-api-sli.md
@@ -1,7 +1,7 @@
 ---
 package: Trellis.ServiceLevelIndicators
 namespaces: [Trellis.ServiceLevelIndicators]
-types: [ServiceLevelIndicator, ServiceLevelIndicatorOptions, MeasuredOperation, SliOutcome, IEnrichmentContext, "IEnrichment<T>", IServiceLevelIndicatorBuilder, ServiceLevelIndicatorMeterProviderBuilderExtensions, AddServiceLevelIndicator, AddServiceLevelIndicatorInstrumentation]
+types: [ServiceLevelIndicator, ServiceLevelIndicatorOptions, MeasuredOperation, IEnrichmentContext, "IEnrichment<T>", ServiceLevelIndicatorMeterProviderBuilderExtensions]
 version: v10
 last_verified: 2026-06-18
 audience: [llm]


### PR DESCRIPTION
## Summary

Pre-publish maintenance before republishing the SLI packages (which carry the new API-reference front matter from #61).

## NuGet bumps (`Directory.Packages.props`)

Stay-current minor/patch bumps. `dotnet list package --vulnerable --include-transitive` flagged **nothing** — these are not security fixes.

| Package | From | To |
|---|---|---|
| OpenTelemetry (core, Exporter.Console, Exporter.OTLP, Extensions.Hosting) | 1.15.3 | 1.16.0 |
| Scalar.AspNetCore (+ .Microsoft) | 2.14.4 | 2.16.4 |
| Microsoft.Extensions.* (DI.Abstractions, Options, Logging.Console) | 10.0.7 | 10.0.9 |
| Microsoft.AspNetCore.OpenApi, Microsoft.AspNetCore.TestHost | 10.0.7 | 10.0.9 |
| Azure.Core | 1.54.0 | 1.59.0 |
| DotNet.ReproducibleBuilds | 2.0.2 | 2.0.5 |
| FluentAssertions | 7.2.0 | 7.2.2 |

**Held deliberately:**
- **FluentAssertions** stays on 7.x — 8.x is the paid-license change (per repo `copilot-instructions.md`).
- **Microsoft.Testing.Extensions.TrxReport** `1.9.1` and **CodeCoverage** `18.0.6` — kept aligned with xunit.v3's `Microsoft.Testing.Platform` 1.9.x (per the existing comment in the props file).
- **Asp.Versioning.OpenApi** `10.0.0-rc.1` — no newer version on the sources.

## Docs

Tightens the `types:` front matter (added in #61) to each doc's actual documented `### type` sections — addresses the review feedback on #61. Removed method names and types whose `###` sections live in a sibling doc:
- `trellis-api-sli.md`: drop `SliOutcome`, `IServiceLevelIndicatorBuilder`, `AddServiceLevelIndicator`, `AddServiceLevelIndicatorInstrumentation`.
- `trellis-api-sli-apiversioning.md`: drop `AddApiVersion`.

## Verification

`dotnet build -c Release`: **0 warnings / 0 errors**. `dotnet test`: **99 passed / 0 failed** across all three test projects.
